### PR TITLE
fix(deps): update rustls-webpki to 0.103.12 for security patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Updates `rustls-webpki` from 0.103.10 → 0.103.12 to resolve two open security advisories:

- Closes #34 (RUSTSEC-2026-0098): Name constraints for URI names were incorrectly accepted
- Closes #35 (RUSTSEC-2026-0099): Name constraints were accepted for certificates asserting a wildcard name

Both patched in rustls-webpki 0.103.12.